### PR TITLE
Bypassing COUException in application raised during plan generation sanity checks

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -360,6 +360,8 @@ class OpenStackApplication(Application):
         :type units: Optional[list[Unit]], optional
         :raises ApplicationError: When enable-auto-restarts is not enabled.
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
+        :raises MismatchedOpenStackVersions:  When the units of the app are running
+            different OpenStack versions
         """
         self._check_application_target(target)
         self._check_mismatched_versions(units)


### PR DESCRIPTION
COU generates and prints plan even if some in-scope applications failed their pre-plan sanity checks. These applications will be excluded from the plan and their error log messages will be printed after plan generation.

Additionally, if any error is catched this way during plan generation, COU blocks upgrades from running.

Here is an demonstration of what the output would be like if `rabbitmq-server` and `keystone` fail to pass their sanity checks when running `cou upgrade`
```
$ cou upgrade
Full execution log: '/home/ubuntu/.local/share/cou/log/cou-20231215211917.log'
Connected to 'test-model' ✔
Analyzing cloud... ✔
Generating upgrade plan... ✔
Upgrade cloud from 'ussuri' to 'victoria'
    Verify that all OpenStack applications are in idle state
    Back up MySQL databases
    Control Plane principal(s) upgrade plan
    Upgrade plan for 'cinder' to 'victoria'
        Upgrade software packages of 'cinder' from the current APT repositories
            Upgrade software packages on unit cinder/0
        Refresh 'cinder' to the latest revision of 'ussuri/stable'
        Upgrade 'cinder' to the new channel: 'victoria/stable'
        Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
        Wait for up to 300s for app 'cinder' to reach the idle state
        Verify that the workload of 'cinder' has been upgraded
    ... (other applications in the plan)
Error: Cannot generate plan for 'rabbitmq-server'.
    COU does not currently support upgrading applications that disable service restarts. Please enable charm option enable-auto-restart and rerun COU to upgrade the rabbitmq-server application.
Error: Cannot generate plan for 'keystone'. 
    Units of application keystone are running mismatched OpenStack versions: 'victoria': keystone/0, keystone/2, 'ussuri': keystone/1
Not possible to run upgrades. Please fix the errors before proceeding.
```